### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+env:
+  X_PYTHON_MIN_VERSION: "3.11"
+
+jobs:
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{env.X_PYTHON_MIN_VERSION }}
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Create source and wheel dist
+      # (2024-12-11, s-heppner)
+      # The PyPI Action expects the dist files in a toplevel `/dist` directory,
+      # so we have to specify this as output directory here.
+      run: |
+        python -m build --outdir dist
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This adds a GitHub workflow to automatically release the project to PyPI, when triggering a GitHub release. It is based on PyPIs trusted publisher concept.