### PR TITLE
Add test for empty field values

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -157,6 +157,31 @@ id456,
         expected = "\\url{https://example.org/query?x=1&y=2}"
         self.assertEqual(expected, actual)
 
+    def test_empty_field_value(self) -> None:
+        bibtex_string = """@misc{test_entry,
+          note = ,
+        }"""
+        entry = BibTeXEntry.from_string(bibtex_string)
+        actual = entry.fields.get("note")
+        expected = ""
+        self.assertEqual(expected, actual)
+
+        bibtex_string = """@misc{test_entry,
+                  note = {},
+                }"""
+        entry = BibTeXEntry.from_string(bibtex_string)
+        actual = entry.fields.get("note")
+        expected = ""
+        self.assertEqual(expected, actual)
+
+        bibtex_string = """@misc{test_entry,
+                  note = {{}},
+                }"""
+        entry = BibTeXEntry.from_string(bibtex_string)
+        actual = entry.fields.get("note")
+        expected = ""
+        self.assertEqual(expected, actual)
+
 
 class TestSplitEntries(unittest.TestCase):
     def test_single_entry(self) -> None:


### PR DESCRIPTION
In #4, we thought that a completely empty field value causes a non- descriptive error message. This must have been a different error, since I could not reproduce it again.

However, to be sure, this adds a unittest with a completely empty field value.

Fixes #4