### PR TITLE
Fix bug in the ieeetr_rules.check_article rule

### DIFF
--- a/bibtex_linter/ieeetr_rules.py
+++ b/bibtex_linter/ieeetr_rules.py
@@ -26,7 +26,6 @@ def check_article(entry: BibTeXEntry) -> List[str]:
     }
     omitted_fields: Set[str] = {
         "language",
-        "number",
         "url",
     }
     invariant_violations.extend(check_required_fields(entry, required_fields))


### PR DESCRIPTION
Previously, the field `number` was considered to be ommitted in the rendered bibliography, which turned out to be a bug, as it is being rendered.
This removes the `number` field from the `ommitted_fields` in the linter rule.

Fixes #13