### PR TITLE
Fix inverted logic in `check_disallowed_field`

### DIFF
--- a/bibtex_linter/verification.py
+++ b/bibtex_linter/verification.py
@@ -85,7 +85,7 @@ def check_disallowed_field(entry: BibTeXEntry, field: str, explanation: str) -> 
     If it does exist, include the explanation sentence in the invariant violation text to help the user understand
     why it is disallowed.
     """
-    if field not in entry.fields.keys():
+    if field in entry.fields.keys():
         return [f"Entry '{entry.name}' contains disallowed field [{field}]. {explanation}"]
     return []
 


### PR DESCRIPTION
Previously, the logic of the `verification.check_disallowed_field` method was inverted. Instead of returning a violation when the disallowed field was present, it was returning the violation when it was not present. My suspicion is that this was due to a copy/paste error.

This fixes this bug, by returning a violation only when a disallowed field is present.
The bug was first found in the logic of the linter rule of: `ieeetran_rules.check_in_collection`.

Fixes #18